### PR TITLE
Add Target Selection fallback & avoid overflows

### DIFF
--- a/Assets/countdownScript.cs
+++ b/Assets/countdownScript.cs
@@ -24,7 +24,7 @@ public class countdownScript : MonoBehaviour
     private List<int> selectedLarge = new List<int>();
 
     public TextMesh targetText;
-    private int target;
+    private int target = 1; //just in case, not 0 because it would auto-solve
     private int chosenEquation = 0;
 
     private ClickableNumbers firstPress;
@@ -39,6 +39,7 @@ public class countdownScript : MonoBehaviour
     private int equationsDone = 0;
     private int boardFirst = 0;
     private int mostRecentSolve = 0;
+    private bool[] solutionTest = new bool[15];
 
     //Logging
     static int moduleIdCounter = 1;
@@ -82,7 +83,16 @@ public class countdownScript : MonoBehaviour
     void Start()
     {
         GenerateNumbers();
-        GenerateTarget();
+        while ((target < 100 || target > 1000))
+        {
+            if (!(solutionTest.Contains(false))) //this avoids infinite loops
+            {
+                GenerateNumbers();
+                for (int i = 0; i < 15; i++) solutionTest[i] = false;
+            }
+            GenerateTarget();
+            solutionTest[chosenEquation] = true; //mark the equation as used
+        }
         Logging();
     }
 
@@ -126,7 +136,6 @@ public class countdownScript : MonoBehaviour
         {
             numbers[i].position = i;
         }
-        Debug.LogFormat("[Countdown #{0}] Your numbers are {1}, {2}, {3}, {4}, {5} & {6}.", moduleId, selectedNumbers[0], selectedNumbers[1], selectedNumbers[2], selectedNumbers[3], selectedNumbers[4], selectedNumbers[5]);
     }
 
     void GenerateTarget()
@@ -204,16 +213,12 @@ public class countdownScript : MonoBehaviour
         {
             target = ((selectedNumbers[1] - selectedNumbers[4]) + (selectedNumbers[0] - selectedNumbers[2])) * selectedNumbers[5];
         }
-
-        if(target > 1000 || target < 100)
-        {
-            GenerateTarget();
-        }
     }
 
     void Logging()
     {
         targetText.text = target.ToString();
+        Debug.LogFormat("[Countdown #{0}] Your numbers are {1}, {2}, {3}, {4}, {5} & {6}.", moduleId, selectedNumbers[0], selectedNumbers[1], selectedNumbers[2], selectedNumbers[3], selectedNumbers[4], selectedNumbers[5]);
         Debug.LogFormat("[Countdown #{0}] Your target is {1}.", moduleId, target);
         if(chosenEquation == 0)
         {

--- a/Assets/countdownScript.cs
+++ b/Assets/countdownScript.cs
@@ -82,6 +82,7 @@ public class countdownScript : MonoBehaviour
 
     void Start()
     {
+        for (int i = 0; i < 15; i++) solutionTest[i] = false;
         GenerateNumbers();
         while ((target < 100 || target > 1000))
         {


### PR DESCRIPTION
Changes: 
1.) Moved number logging to `Logging();` to ensure that it didn't happen twice. 
2.) Change the target testing to a `while` loop so that we don't have another Stack Overflow. 
3.) Added a failsafe to regenerate the numbers if all equations have been tested. 
4.) Changed `private int target;` to `private int target = 1;` to make sure that it doesn't have an error. 